### PR TITLE
Clarify where the Point class comes from,  add warnings for latlng

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Mongoid Extension that simplifies the use of MongoDB spatial features.
 Quick Start
 -----------
 
-This gem focus on (making helpers for) MongoDB's spatial features.
+This gem focuses on (making helpers for) MongoDB's spatial features.
 But you may also use an external Geometric/Spatial gem alongside.
 
 ```ruby
@@ -67,12 +67,16 @@ Place.create_indexes
 Points
 ------
 
+This gem defines a specific Point class under the Mongoid::Geospatial namespace. Make sure to use `type: ::Mongoid::Geospatial::Point` to avoid name errors or collisions with other Point class you might already have defined `NameError`s
+
 Currently, MongoDB supports query operations on 2D points only, so that's what this lib does. All geometries apart from points are just arrays in the database. Here's is how you can input a point as:
 
 * longitude latitude array in that order - [long,lat] ([x, y])
 * an unordered hash with latitude key(:lat, :latitude) and a longitude key(:lon, :long, :lng, :longitude)
 * an ordered hash with longitude as the first item and latitude as the second item; this hash does not have include the latitude and longitude keys
 * anything with the a method #to_xy or #to_lng_lat that converts itself to  [long, lat] array
+
+_Note : the convention of having longitude as the first coordinate may vary for other libraries. For instance, Google Maps often refer to "LatLng". Make sure you keep those differences in mind_
 
 We store data in the DB as a [x, y] array then reformat when it is returned to you
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Place.create_indexes
 Points
 ------
 
-This gem defines a specific `Point` class under the Mongoid::Geospatial namespace. Make sure to use `type: ::Mongoid::Geospatial::Point` to avoid name errors or collisions with other `Point` classes you might already have defined `NameError`s
+This gem defines a specific `Point` class under the Mongoid::Geospatial namespace. Make sure to use `type: ::Mongoid::Geospatial::Point` to avoid name errors or collisions with other `Point` classes you might already have defined `NameError`s.
 
 Currently, MongoDB supports query operations on 2D points only, so that's what this lib does. All geometries apart from points are just arrays in the database. Here's is how you can input a point as:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Place.create_indexes
 Points
 ------
 
-This gem defines a specific Point class under the Mongoid::Geospatial namespace. Make sure to use `type: ::Mongoid::Geospatial::Point` to avoid name errors or collisions with other Point class you might already have defined `NameError`s
+This gem defines a specific `Point` class under the Mongoid::Geospatial namespace. Make sure to use `type: ::Mongoid::Geospatial::Point` to avoid name errors or collisions with other `Point` classes you might already have defined `NameError`s
 
 Currently, MongoDB supports query operations on 2D points only, so that's what this lib does. All geometries apart from points are just arrays in the database. Here's is how you can input a point as:
 
@@ -76,7 +76,7 @@ Currently, MongoDB supports query operations on 2D points only, so that's what t
 * an ordered hash with longitude as the first item and latitude as the second item; this hash does not have include the latitude and longitude keys
 * anything with the a method #to_xy or #to_lng_lat that converts itself to  [long, lat] array
 
-_Note : the convention of having longitude as the first coordinate may vary for other libraries. For instance, Google Maps often refer to "LatLng". Make sure you keep those differences in mind_
+_Note: the convention of having longitude as the first coordinate may vary for other libraries. For instance, Google Maps often refer to "LatLng". Make sure you keep those differences in mind._
 
 We store data in the DB as a [x, y] array then reformat when it is returned to you
 


### PR DESCRIPTION
When writing a concern one needs to know the "Point" actually is from `::Mongoid::Geospatial::Point`
Also I have ran into convention problems, as google treats coordinates as [latitude, longitude] and not the opposite.
I would actually strongly discourage the use of arrays as much as possible